### PR TITLE
Allow javascript style comments in manifest.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@types/chrome": "^0.0.268",
         "@types/firefox-webext-browser": "^120.0.3",
         "ajv": "^6.12.6",
+        "jsonc-parser": "^3.3.1",
         "mustache": "^4.2.0",
         "webpack-sources": "^3.2.3",
         "ws": "^8.16.0"
@@ -5180,6 +5181,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="
     },
     "node_modules/keyv": {
       "version": "4.5.4",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@types/chrome": "^0.0.268",
     "@types/firefox-webext-browser": "^120.0.3",
     "ajv": "^6.12.6",
+    "jsonc-parser": "^3.3.1",
     "mustache": "^4.2.0",
     "webpack-sources": "^3.2.3",
     "ws": "^8.16.0"

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -5,6 +5,7 @@ import webpack, { Compiler, Compilation, Stats } from "webpack";
 import Mustache from "mustache";
 import { constants, readFileSync } from "fs";
 import { access } from "fs/promises";
+import { stripComments } from "jsonc-parser";
 import vendors from "./vendors.json";
 import {
   Manifest,
@@ -12,7 +13,6 @@ import {
   transformManifestValuesFromENV,
   transformManifestVendorKeys,
 } from "./manifest";
-import { stripComments } from "jsonc-parser";
 
 const { WebpackError } = webpack;
 

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -12,6 +12,7 @@ import {
   transformManifestValuesFromENV,
   transformManifestVendorKeys,
 } from "./manifest";
+import { stripComments } from "jsonc-parser";
 
 const { WebpackError } = webpack;
 
@@ -164,7 +165,7 @@ class WebextensionPlugin {
     const manifestBuffer = readFileSync(manifestPath, {
       encoding: "utf8",
     });
-    const manifest = JSON.parse(manifestBuffer);
+    const manifest = JSON.parse(stripComments(manifestBuffer));
     const serviceWorker = manifest?.background?.service_worker ?? null;
 
     if (
@@ -374,11 +375,13 @@ class WebextensionPlugin {
         compilation.options.context,
         this.manifestNameDefault
       );
-      const manifestBuffer = await this.readFile(manifestPath);
+      const manifestBuffer = readFileSync(manifestPath, {
+        encoding: "utf8",
+      });
       let manifest: Manifest;
       // Convert to JSON
       try {
-        manifest = JSON.parse(manifestBuffer);
+        manifest = JSON.parse(stripComments(manifestBuffer));
       } catch (error) {
         throw new Error(`Could not parse ${this.manifestNameDefault}`);
       }


### PR DESCRIPTION
Hi there, not sure you are open to this. But since I implemented it on a fork, I might as well open a PR and get your feedback.

**Context**

I have a `manifest.json` with comments inside that I want to keep. They are allowed according to https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json

But the plugin currently expects pure JSON (i.e. no comments allowed).

**Summary**

Before parsing JSON, strip comments from manifest.json. This way they are not included in the production build, where I personally do not need them, but it is okay to have them in the original manifest.json.

I believe this behaviour could be irritating to other users though. It would need to be documented. Alternatively, change the approach and use jsonc module for parsing as well.

**Test Plan**

npm run test

Plus some manual testing by installing my forked version locally and using it to package a manifest.json with comments.   